### PR TITLE
Change init.cmd to work from any directory

### DIFF
--- a/init.cmd
+++ b/init.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy Bypass -Command .\init.ps1
+powershell -ExecutionPolicy Bypass -Command %~dp0\init.ps1
 set PATH=%~dp0.tools;%~dp0.tools\VSS.NuGet.AuthHelper;%PATH%


### PR DESCRIPTION
Right now, you can only run init.cmd from the directory that it is stored in. This is because it is running init.ps1 using the relative path so it looks in the current directory for the init script.
This change makes it use the same directory as the path the init.cmd script its in.